### PR TITLE
chore: Add base64 to PDF converter functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.txt
+*.pdf

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# base64Converter
-A base64 converter on local
+# Welcome
+
+## This is an application that allows you to convert base64 encoded files to PDF files
+
+### Why is this project necessary?
+
+In many cases, sensitive information needs to be shared or stored in a secure manner. By converting files to a base64 string, the data can be encapsulated and transmitted as plain text, ensuring that it remains intact and unaltered during transit. This project allows you to convert those base64 encoded strings back into their original PDF format, ensuring the privacy and integrity of the data.
+
+### How to use it?
+
+1. Run the installation command: ```pip install -r requirements.txt```
+
+2. You can run the application by running the command: ``` python converter.py --input fileToConvert.txt --output output.pdf ```
+
+### Command line arguments
+
+- --input: The path to the file that contains the base64 string you want to convert to a PDF file.
+- --output: The path where you want to save the PDF file.
+
+### Example
+
+- Create a text file (e.g., fileToConvert.txt) that contains the base64 string.
+- Run the conversion command:
+  
+  ```bash
+    python converter.py --input fileToConvert.txt --output output.pdf
+  ```

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,29 @@
+import argparse
+import base64
+
+
+def base64_file_to_pdf(input_file, output_file):
+    with open(input_file, 'r') as file:
+        base64_str = file.read()
+
+    pdf_data = base64.b64decode(base64_str)
+
+    with open(output_file, 'wb') as file:
+        file.write(pdf_data)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert a base64 encoded file to a PDF file.')
+    parser.add_argument('--input', type=str, required=True,
+                        help='File with the base64 encoded data.')
+    parser.add_argument('--output', type=str, required=True,
+                        help='Output PDF file.')
+
+    args = parser.parse_args()
+
+    base64_file_to_pdf(args.input, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds the functionality to convert base64 encoded files to PDF files. It includes a new `converter.py` file that contains the necessary code for the conversion. The `README.md` file has been updated to provide instructions on how to use the application and the command line arguments required. The `.gitignore` file has also been updated to ignore `.txt` and `.pdf` files.

Note: This commit message follows the conventional commit format, starting with a type (chore) and a concise description of the changes made.