### PR TITLE
Add support for file-to-base64 conversion and optional output parameter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.0] - 2024-07-19
+
+### Added
+
+- Support for converting files to base64 string.
+- Optional output file parameter, allowing conversion result to be printed to the screen if not specified.
+- Mode selection via -m or --mode argument to choose between "to_base64" and "from_base64". 
+
+
 ## [1.1.0] - 2024-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ In many cases, sensitive information needs to be shared or stored in a secure ma
 ### Command line arguments
 
 - -i, --input: The path to the file that contains the base64 string you want to convert to any file format.
-- -o, --output: The path where you want to save the converted file.
+- -o, --output: The path where you want to save the converted file. Is required when converting from base64 to a file format.
 - h, --help: Show the help message and exit.
+- -m, --mode: The mode of the conversion. It can be either "to_base64" or "from_base64". The default mode is "from_base64".
 
 ### Example
 

--- a/converter.py
+++ b/converter.py
@@ -2,29 +2,51 @@ import argparse
 import base64
 
 
-def base64_file_to_pdf(input_file, output_file):
+def base64_to_file(input_file, output_file=None):
+    if not output_file:
+        print('Output file is required for this mode.')
+        return
+
     with open(input_file, 'r') as file:
         base64_str = file.read()
 
-    pdf_data = base64.b64decode(base64_str)
+    file_data = base64.b64decode(base64_str)
 
     with open(output_file, 'wb') as file:
-        file.write(pdf_data)
-
+        file.write(file_data)
     print(f"File converted successfully: {output_file}")
+
+
+def file_to_base64(input_file, output_file=None):
+    with open(input_file, 'rb') as file:
+        file_data = file.read()
+
+    base64_str = base64.b64encode(file_data).decode('utf-8')
+
+    if output_file:
+        with open(output_file, 'w') as file:
+            file.write(base64_str)
+        print(f"File converted successfully: {output_file}")
+    else:
+        print(base64_str)
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert a base64 encoded file to a file.')
+        description='Convert a file to/from base64.')
     parser.add_argument('-i', '--input', type=str, required=True,
-                        help='File with the base64 encoded data.')
+                        help='Input file.')
     parser.add_argument('-o', '--output', type=str,
-                        required=True, help='Output file.')
+                        help='Output file (optional).')
+    parser.add_argument('-m', '--mode', type=str, required=True, choices=['to_base64', 'from_base64'],
+                        help='Conversion mode: "to_base64" or "from_base64".')
 
     args = parser.parse_args()
 
-    base64_file_to_pdf(args.input, args.output)
+    if args.mode == 'to_base64':
+        file_to_base64(args.input, args.output)
+    elif args.mode == 'from_base64':
+        base64_to_file(args.input, args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary

This pull request adds new functionality to support converting files to base64 strings and vice versa. It includes enhancements such as an optional output file parameter and a mode selection to choose between "to_base64" and "from_base64".

## Details

- Mode Selection: Introduced a new argument -m or --mode to specify the conversion mode ("to_base64" or "from_base64").
- Optional Output File: The output file parameter is now optional. If not specified, the conversion result will be printed to the screen.
- Enhanced Documentation: Updated the script description and argument details to reflect the new functionality.
- Changelog Updated: The changelog has been updated to reflect these changes under version 1.2.0.

## Testing

- Verified that the conversion from base64 to file and from file to base64 works as expected.
- Confirmed that the optional output file parameter functions correctly, printing the result to the screen if not provided.

## Impact

- These changes enhance the flexibility and usability of the script, allowing for more versatile file conversion operations.

Please review the changes and provide any feedback.
